### PR TITLE
增强沙箱能力支持shadow-dom

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ satumCore.use(proxySandboxMidware);
 
 // use options
 // satumCore.use(proxySandboxMidware, {
-//   winVariable(k, fakeWin, realWin): any,
-//   docVariable(k, fakeDoc, realDoc): any,
+//   useSandBox: true, // 启用css shadow-dom 默认为true
+//   winVariable(k, fakeWin, realWin): any,   // 劫持fakeWin属性
+//   docVariable(k, fakeDoc, realDoc): any,   // 劫持docVariable属性
+//   locationVariable(k, locationProx, location, fakeWin )  // 劫持location属性
 // });
 ```

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -8,7 +8,7 @@ jest.mock('./properties');
 describe('@satumjs/midware-proxy-sandbox test', () => {
   let Sandbox: any;
   beforeEach(() => {
-    const fakeSystem = { options: {}, set: jest.fn() } as any;
+    const fakeSystem = { options: {}, set: jest.fn(), use: jest.fn() } as any;
     const microApps: any[] = [{ name: 'foo' }, { name: 'bar' }];
     const next = jest.fn();
     proxySandboxMidware(fakeSystem, microApps, next);
@@ -32,7 +32,7 @@ describe('@satumjs/midware-proxy-sandbox test', () => {
 
     expect(sandbox.vmContext === window[sandbox.fakeWindowName]).toBe(true);
     expect(sandbox.vmContext['DRIVE_BY_SATUMMICRO']).toBe(true);
-    (getFakeDocument as any).mock.calls[0][0]();
+    // (getFakeDocument as any).mock.calls[0][0]();
     dateSpy.mockRestore();
   });
 
@@ -75,7 +75,7 @@ describe('@satumjs/midware-proxy-sandbox runScript test', () => {
   let wrapper: HTMLElement;
   let childNode: HTMLElement;
   beforeEach(() => {
-    const fakeSystem = { options: {}, set: jest.fn() } as any;
+    const fakeSystem = { options: {}, set: jest.fn(), use: jest.fn() } as any;
     const microApps: any[] = [{ name: 'foo' }, { name: 'bar' }];
     const next = jest.fn();
     proxySandboxMidware(fakeSystem, microApps, next);
@@ -151,14 +151,14 @@ describe('@satumjs/midware-proxy-sandbox runScript test', () => {
     sandbox.exec(getJSCode as any).then(() => {
       expect(fakeDoc.createElement).toBeCalledTimes(1);
       expect(childNode.setAttribute).toBeCalledTimes(2);
-      expect((childNode as any).text).toBe("with(window['foo']){\naaa\n}");
+      expect((childNode as any).text).toMatch("with(window['foo']){\naaa\n}");
 
       // next to syncFile
       fakeDoc.createElement.mockReturnValueOnce(childNode);
       const syncFile = { source: { content: Promise.resolve('bbb') } };
       const syncFile2 = { source: { content: Promise.resolve() } };
       sandbox.exec((() => Promise.resolve([syncFile, syncFile2])) as any).then(() => {
-        expect((childNode as any).text).toBe("with(window['foo']){\nbbb\n}");
+        expect((childNode as any).text).toMatch("with(window['foo']){\nbbb\n}");
         spy.mockRestore();
         done();
       });

--- a/src/midware/fontFaceMidware.ts
+++ b/src/midware/fontFaceMidware.ts
@@ -1,0 +1,29 @@
+import { FileType, IMicroApp, MidwareName, MidwareSystem, NextFn } from "@satumjs/types";
+
+const fontFaceSet = new Set()
+export function fontFaceMidware(system: MidwareSystem, microApps: IMicroApp[], next: NextFn) {
+  const fontFaceRuleReg = /@font-face[\s]*\{([\w\W](?![\{\}]))+[^\}]\}/g;
+  system.set(MidwareName.code, function(code: string, url: string) {
+    if (fontFaceSet.has(url)) return;
+    fontFaceSet.add(url);
+
+    var extName = system.fileExtName(url);
+
+    const app = microApps.find((function(app) {
+        return app.fileExtNameMap[url]
+    }));
+
+    if (extName !== FileType.CSS) return;
+
+    const fontFaceRuleContent = code.match(fontFaceRuleReg);
+    if (fontFaceRuleContent) {
+      const style = document.createElement('style');
+      style.textContent = fontFaceRuleContent.join('\n');
+      style.setAttribute('data-url', url);
+      style.setAttribute('app-name', (app && app.name) || '');
+      document.head.appendChild(style);
+    }
+  })
+
+  next();
+}

--- a/src/midware/index.ts
+++ b/src/midware/index.ts
@@ -1,0 +1,2 @@
+export {fontFaceMidware} from './fontFaceMidware'
+export {shadowRootMidware} from './shadowRootMidware'

--- a/src/midware/shadowRootMidware.ts
+++ b/src/midware/shadowRootMidware.ts
@@ -1,0 +1,74 @@
+import { IMicroApp, MidwareSystem, NextFn, PluginEvent } from "@satumjs/types";
+
+function traverseNode(el: HTMLElement, vmContext:any) {
+
+  if (el.ownerDocument === document) {
+    Object.defineProperty(el, 'ownerDocument', {
+      get() {
+        return vmContext.document;
+      }
+    })
+  };
+  
+
+  Array.from(el.childNodes).forEach((child: HTMLElement) => {
+    traverseNode(child, vmContext);
+  })
+}
+
+const getAppShadowRoot = (container: String | HTMLElement, vmContext: any) => {
+  let shadowRoot:any = null;
+  if (typeof container === 'string') {
+    container = document.querySelector(container) as any;
+  }
+
+  if (!(container instanceof HTMLElement)) {
+    throw Error('app config rule of container property is css Selector or HTMLElement')
+  }
+
+  if (container instanceof ShadowRoot) {
+    shadowRoot = container;
+  }
+
+  if (container.shadowRoot instanceof ShadowRoot) {
+    shadowRoot = container.shadowRoot;
+  }
+
+  if (!shadowRoot) {
+    shadowRoot = container.attachShadow({mode: 'open'});
+  }
+
+  shadowRoot.getElementsByTagName = function(tagName:string) {
+    return shadowRoot.querySelectorAll(tagName);
+  }
+
+  shadowRoot.getElementsByClassName = function(className:string) {
+    return shadowRoot.querySelectorAll(`.${className}`);
+  }
+
+  const appendChild = shadowRoot.appendChild.bind(shadowRoot);
+  shadowRoot.appendChild = function(el:HTMLElement) {
+    traverseNode(el, vmContext);
+    return appendChild(el);
+  }
+
+
+  shadowRoot.tagName = '';
+  shadowRoot.getAttribute = () => null;
+  
+  return shadowRoot;
+}
+
+export function shadowRootMidware(system: MidwareSystem, microApps: IMicroApp[], next: NextFn) {
+  system.event(`_${PluginEvent.sandboxRouteHistory}`, ({vm}) => {
+    microApps.find(app => {
+      const actors = app.getRefActors();
+      return actors.find((actor) => {
+        vm.document.shadowRoot = actor.container = getAppShadowRoot(actor.container, actor.sandbox.vmContext);
+        return (actor.sandbox.vmContext === vm)
+      })
+    })
+  })
+
+  next();
+}

--- a/src/properties/body.ts
+++ b/src/properties/body.ts
@@ -1,0 +1,9 @@
+import { ISandbox } from '@satumjs/types';
+import { satumMicroHeadAppendChildFactory } from '@satumjs/async-override';
+
+export function getFakeBody(sandbox: ISandbox) {
+  const xBody = sandbox.appWrap;
+  const body = document.body;
+
+  return xBody;
+}

--- a/src/properties/cleanWin.ts
+++ b/src/properties/cleanWin.ts
@@ -1,0 +1,10 @@
+import { FakeDocument, FakeLocation, FakeWindow, ISandbox, KeyObject } from '@satumjs/types';
+import { CtxEventDB } from './event';
+
+const iframe = document.createElement('iframe');
+iframe.style.display = 'none';
+document.body.append(iframe);
+
+export function getCleanWindow() {
+  return iframe.contentWindow;
+}

--- a/src/properties/document.ts
+++ b/src/properties/document.ts
@@ -1,59 +1,98 @@
-import { FakeDocument, FnWithArgs, KeyObject } from '@satumjs/types';
+import { FakeDocument, FnWithArgs, ISandbox, KeyObject } from '@satumjs/types';
+import { ProxySandboxOptions } from '../type';
+import { CtxEventDB } from './event';
 
-function getFakeDocumentElement(fakeDocument: FakeDocument) {
-  const htmlNode = document.body.parentNode as HTMLElement;
-  return new Proxy(htmlNode, {
-    get(target: any, p: string) {
-      if (p === 'parentNode') return fakeDocument;
-      return typeof target[p] === 'function' ? target[p].bind(htmlNode) : target[p];
-    },
-  });
-}
 
-export function getFakeDocument(getFakeHead: FnWithArgs<HTMLElement, []>, options: KeyObject<any>) {
+
+export function getFakeDocument( 
+  ctxDocEventDatabase: CtxEventDB,
+  getFakeWin: () => ISandbox['vmContext'],
+  getFakeDocumentElement: FnWithArgs<HTMLElement, []>,  
+  getFakeHead: FnWithArgs<HTMLElement, []>, 
+  getFakeBody: FnWithArgs<HTMLElement, []>,
+  options: ProxySandboxOptions
+) {
+
   let fakeDocumentElement: HTMLElement;
   let fakeHeadNode: HTMLElement;
+  let fakeBodyNode: HTMLElement;
+  let shadowRoot: ShadowRoot;
+ 
+
   const proxyDoc = Object.create(null);
+  const docProxyKey = new Set([
+    'getElementById',
+    'getElementsByClassName',
+    'getElementsByClassName',
+    'getElementsByName',
+    'querySelector',
+    'querySelectorAll'
+  ]);
+
+  const docGetter =  (_: Document, k: string) => {
+    const fakeWin = getFakeWin();
+    
+    if (k === 'head') {
+      return fakeHeadNode || (fakeHeadNode = getFakeHead());
+    }
+
+    if (k === 'documentElement') {
+      return fakeDocumentElement || (fakeDocumentElement = getFakeDocumentElement());
+    }
+
+    if (k === 'getElementsByTagName' || k === 'querySelector' || k === 'querySelectorAll') {
+      const originFn = document[k].bind(document);
+      const isReturnArray = k !== 'querySelector';
+      return (selector: string) => {
+        if (selector === 'html') {
+          const curHtmlNode = fakeDocumentElement || (fakeDocumentElement = getFakeDocumentElement());
+          return isReturnArray ? [curHtmlNode] : curHtmlNode;
+        }
+        if (selector === 'head') {
+          const curHeadNode = fakeHeadNode || (fakeHeadNode = getFakeHead());
+          return isReturnArray ? [curHeadNode] : curHeadNode;
+        }
+        return originFn(selector);
+      };
+    }
+
+    if (k === 'body') {
+      return fakeBodyNode || (fakeBodyNode = getFakeBody())
+    }
+
+    // custom returns
+    if (typeof options.docVariable === 'function') {
+      const result = options.docVariable(k, proxyDoc, document, fakeWin);
+      if (result !== undefined && result !== null) return result;
+    }
+
+    const isProxyKey = k in proxyDoc;
+    const val = isProxyKey ? proxyDoc[k] : document[k];
+    return typeof val === 'function' ? val.bind(isProxyKey ? proxyDoc : document) : val;
+  }
 
   const fakeDocument: FakeDocument = new Proxy(proxyDoc, {
-    get: (_: Document, k: string) => {
-      // fake head
-      if (k === 'head') {
-        return fakeHeadNode || (fakeHeadNode = getFakeHead());
-      }
+    get:(_: Document, k: string)  => {
+      const originFn = docGetter(_, k);
+      shadowRoot = shadowRoot || proxyDoc.shadowRoot;
 
-      if (k === 'documentElement') {
-        return fakeDocumentElement || (fakeDocumentElement = getFakeDocumentElement(fakeDocument));
-      }
-
-      if (k === 'getElementsByTagName' || k === 'querySelector' || k === 'querySelectorAll') {
-        const originFn = document[k].bind(document);
-        const isReturnArray = k !== 'querySelector';
-        return (selector: string) => {
-          if (selector === 'html') {
-            const curHtmlNode = fakeDocumentElement || (fakeDocumentElement = getFakeDocumentElement(fakeDocument));
-            return isReturnArray ? [curHtmlNode] : curHtmlNode;
+      if (shadowRoot instanceof ShadowRoot && docProxyKey.has(k) && shadowRoot[k]) {
+        return (selector:string) => {
+          if (selector === 'html' || selector === 'head') {
+            return originFn(selector)
           }
-          if (selector === 'head') {
-            const curHeadNode = fakeHeadNode || (fakeHeadNode = getFakeHead());
-            return isReturnArray ? [curHeadNode] : curHeadNode;
-          }
-          return originFn(selector);
-        };
+
+          return shadowRoot[k](selector);
+        }
       }
 
-      // custom returns
-      if (typeof options.docVariable === 'function') {
-        const result = options.docVariable(k, proxyDoc, document);
-        if (result !== undefined && result !== null) return result;
-      }
-
-      const isProxyKey = k in proxyDoc;
-      const val = isProxyKey ? proxyDoc[k] : document[k];
-      return typeof val === 'function' ? val.bind(isProxyKey ? proxyDoc : document) : val;
+      return originFn;
     },
     set: (_: Document, k: PropertyKey, val: any) => {
       if (typeof k === 'string' && ['title'].includes(k)) {
+        document[k] = val;
+      } else if (typeof k === 'string' && k in document && k.startsWith('on')) {
+        ctxDocEventDatabase.push({ event: k, callback: val });
         document[k] = val;
       } else {
         proxyDoc[k] = val;

--- a/src/properties/event.ts
+++ b/src/properties/event.ts
@@ -1,23 +1,111 @@
 import { ISandbox, FnWithArgs } from '@satumjs/types';
 
 type CtxEventFn = FnWithArgs<any, any>;
-export type CtxEventDB = { event: string; callback: CtxEventFn }[];
+
+const callbackWeakMap = new WeakMap<any, any>();
+const proxyHander = (callback: CtxEventFn) => {
+  const callbackProxy = (event:MouseEvent) => {
+    let mouseEvent = event;
+    if (event instanceof MouseEvent) {
+      mouseEvent = new Proxy(Object.create(null), {
+        get(_obj, p) {
+          if (p === 'target') {
+            return ((event as any).path || event.composedPath())[0] || null;
+          }
+    
+          const value = Reflect.get(event, p);
+    
+          if (typeof value === 'function') {
+            return value.bind(event);
+          }
+    
+          return value;
+        }
+      });
+    }
+
+    return callback(mouseEvent);
+  }
+
+  return callbackProxy;
+}
+
+export type CtxEventDB = { event: string; callback: CtxEventFn, useCapture?: boolean }[];
 
 export function handleWinEvent(sandbox: ISandbox, ctxWinEventDatabase: CtxEventDB) {
   const vmContext = sandbox.vmContext;
   const originRemoveEventListener = window.removeEventListener.bind(window);
   vmContext.removeEventListener = (evt: string, callback: CtxEventFn) => {
+    const callbackProxy = callbackWeakMap.get(callback);
+
     const targetEventIndex = ctxWinEventDatabase.findIndex(
-      ({ event: itemEvt, callback: itemCallback }) => itemEvt === evt && itemCallback === callback,
+      ({ event: itemEvt, callback: itemCallback }) => itemEvt === evt && itemCallback === callbackProxy,
     );
     if (targetEventIndex !== -1) ctxWinEventDatabase.splice(targetEventIndex, 1);
-    originRemoveEventListener(evt, callback);
+    originRemoveEventListener(evt, callbackProxy);
   };
 
   const originAddEventListener = window.addEventListener.bind(window);
   vmContext.addEventListener = (evt: string, callback: CtxEventFn, useCapture?: boolean) => {
-    ctxWinEventDatabase.push({ event: evt, callback });
-    return originAddEventListener(evt, callback, useCapture);
+    const callbackProxy = proxyHander(callback)
+    callbackWeakMap.set(callback, callbackProxy);
+    ctxWinEventDatabase.push({ event: evt, callback: callbackProxy });
+    return originAddEventListener(evt, callbackProxy, useCapture);
+  };
+}
+
+export function handleDocEvent(sandbox: ISandbox, ctxDocEventDatabase: CtxEventDB, ) {
+  const vmContext = sandbox.vmContext;
+  const originRemoveEventListener = document.removeEventListener.bind(document);
+  vmContext.document.removeEventListener = (evt: string, callback: CtxEventFn, _useCapture?:boolean) => {
+    // TODO 这里需要去优化
+    const callbackProxy = callbackWeakMap.get(callback);
+
+    const targetEventIndex = ctxDocEventDatabase.findIndex(
+      ({ event: itemEvt, callback: itemCallback }) => itemEvt === evt && itemCallback === callbackProxy,
+    );
+
+    if (targetEventIndex !== -1) {
+      const { event, callback, useCapture } = ctxDocEventDatabase.splice(targetEventIndex, 1) as any;
+      originRemoveEventListener(event, callback, useCapture);
+    }
+  };
+
+  const originAddEventListener = document.addEventListener.bind(document);
+  vmContext.document.addEventListener = (evt: string, callback: CtxEventFn, useCapture?: boolean) => {
+    const callbackProxy = proxyHander(callback)
+    ctxDocEventDatabase.push({ event: evt, callback: callbackProxy, useCapture});
+    callbackWeakMap.set(callback, callbackProxy);
+
+    return originAddEventListener(evt, callbackProxy, useCapture);
+  };
+}
+
+export function handleHtmlEvent(sandbox: ISandbox, ctxHtmlEventDatabase: CtxEventDB, ) {
+  const documentElement = sandbox.vmContext.document.documentElement;
+  const originRemoveEventListener = documentElement.removeEventListener;
+
+  documentElement.removeEventListener = (evt: string, callback: CtxEventFn, _useCapture?:boolean) => {
+    // TODO 这里需要去优化
+    const callbackProxy = callbackWeakMap.get(callback);
+
+    const targetEventIndex = ctxHtmlEventDatabase.findIndex(
+      ({ event: itemEvt, callback: itemCallback }) => itemEvt === evt && itemCallback === callbackProxy,
+    );
+
+    if (targetEventIndex !== -1) {
+      const { event, callback, useCapture } = ctxHtmlEventDatabase.splice(targetEventIndex, 1) as any;
+      originRemoveEventListener(event, callback, useCapture);
+    }
+  };
+
+  const originAddEventListener = documentElement.addEventListener;
+  documentElement.addEventListener = (evt: string, callback: CtxEventFn, useCapture?: boolean) => {
+    const callbackProxy = proxyHander(callback)
+    ctxHtmlEventDatabase.push({ event: evt, callback: callbackProxy, useCapture});
+    callbackWeakMap.set(callback, callbackProxy);
+
+    return originAddEventListener(evt, callbackProxy, useCapture);
   };
 }
 
@@ -30,4 +118,27 @@ export function removeAllWinEvents(ctxWinEventDatabase: CtxEventDB) {
     }
   });
   ctxWinEventDatabase.splice(0, ctxWinEventDatabase.length);
+}
+
+export function removeAllDocEvents(ctxDocEventDatabase: CtxEventDB) {
+  ctxDocEventDatabase.forEach(({ event, callback, useCapture}) => {
+    if (event in document && event.startsWith('on')) {
+      document[event] = null;
+    } else {
+      document.removeEventListener(event, callback, useCapture);
+    }
+  });
+  ctxDocEventDatabase.splice(0, ctxDocEventDatabase.length);
+}
+
+
+export function removeAllHtmlEvents(ctxHtmlEventDatabase: CtxEventDB) {
+  ctxHtmlEventDatabase.forEach(({ event, callback, useCapture}) => {
+    if (event in window && event.startsWith('on')) {
+      document.documentElement[event] = null;
+    } else {
+      document.documentElement.removeEventListener(event, callback, useCapture);
+    }
+  });
+  ctxHtmlEventDatabase.splice(0, ctxHtmlEventDatabase.length);
 }

--- a/src/properties/function.ts
+++ b/src/properties/function.ts
@@ -1,0 +1,21 @@
+export function bindFuncton(func:Function, context:any):Function {
+  return new Proxy<Function>(func, {
+    get(func, p) {
+      const value = Reflect.get(func, p);
+      if (typeof value === 'function') {
+        return bindFuncton(value as Function, func);
+      }
+
+      return value;
+    },
+    set(func, p, val) {
+      return Reflect.set(func, p, val);
+    },
+    apply(func, _, args) {
+      return Reflect.apply(func, context, args);
+    },
+    construct(func, args) {
+      return Reflect.construct(func, args);
+    }
+  })
+}

--- a/src/properties/html.ts
+++ b/src/properties/html.ts
@@ -1,0 +1,35 @@
+
+import { FakeDocument, ISandbox } from '@satumjs/types';
+
+export function getFakeDocumentElement(sandbox: ISandbox) {
+  const htmlNode = document.documentElement;
+  let fakeDocument:FakeDocument|null = null;
+
+  const htmlProxy = Object.create(null);
+  const keys = ['addEventListener', 'removeEventListener'];
+
+  return new Proxy(htmlProxy, {
+    get(target: any, p: string) {
+      if (p === 'parentNode') return fakeDocument || (fakeDocument = sandbox.vmContext.document);
+      if (p === 'ownerDocument') return fakeDocument || (fakeDocument = sandbox.vmContext.document);
+
+      
+      if(target[p] !== void 0) {
+        return target[p];
+      }
+
+      if (htmlNode[p] && typeof htmlNode[p] === 'function') {
+        return htmlNode[p].bind(htmlNode);
+      }
+
+      return htmlNode[p];
+    },
+    set(target:any, p:string, value) {
+      if (keys.includes(p)) {
+        return Reflect.set(target, p, value);
+      }
+
+      return Reflect.set(htmlNode, p, value);
+    }
+  });
+}

--- a/src/properties/index.ts
+++ b/src/properties/index.ts
@@ -1,5 +1,7 @@
-export { CtxEventDB, handleWinEvent, removeAllWinEvents } from './event';
+export { CtxEventDB, handleWinEvent, handleDocEvent, handleHtmlEvent, removeAllWinEvents, removeAllDocEvents, removeAllHtmlEvents } from './event';
+export { getFakeDocumentElement } from './html';
 export { getFakeHead } from './head';
+export { getFakeBody } from './body';
 export { getFakeDocument } from './document';
 export { getFakeLocation } from './location';
-export { getFakeWindow } from './window';
+export { getFakeWindow, getFakeWinBySandbox } from './window';

--- a/src/properties/window.ts
+++ b/src/properties/window.ts
@@ -1,14 +1,22 @@
 import { FakeDocument, FakeLocation, FakeWindow, ISandbox, KeyObject } from '@satumjs/types';
+import { ProxySandboxOptions } from '../type';
+import { getCleanWindow } from './cleanWin';
 import { CtxEventDB } from './event';
+import { bindFuncton } from './function';
+
+export const getFakeWinBySandbox = (sandbox: ISandbox) => {
+  return sandbox.vmContext as ISandbox['vmContext'];
+}
 
 export function getFakeWindow(
   sandbox: ISandbox,
   ctxWinEventDatabase: CtxEventDB,
   fakeDocument: FakeDocument,
   fakeLocation: FakeLocation,
-  options: KeyObject<any>,
+  options: ProxySandboxOptions,
 ) {
   const proxyWin = Object.create(null);
+  const cleanWin = getCleanWindow();
 
   const fakeWin: FakeWindow = new Proxy(proxyWin, {
     get(_: Window, k: PropertyKey) {
@@ -25,6 +33,13 @@ export function getFakeWindow(
       const val = k in proxyWin ? proxyWin[k] : window[k];
       if (typeof k === 'string' && typeof val === 'function') {
         if (/^[A-Z]/.test(k)) return val;
+
+        if (k === 'eval') return val;
+
+        // 来自用户自定义全局属性， 绑定沙盒， 复制静态属性
+        // window.func.staticName = 'name'的问题
+        if (cleanWin && !(k in cleanWin) && (k in proxyWin))  return bindFuncton(val, proxyWin);
+        
         if (k in window) return k.startsWith('on') ? val : val.bind(window);
       }
       return val;
@@ -40,6 +55,9 @@ export function getFakeWindow(
       return true;
     },
     has(_: any, k: PropertyKey): boolean {
+      // 来自用户自定义全局属性， 劫持到沙盒中
+      if (cleanWin && !(k in cleanWin)) return true;
+
       return k in proxyWin || k in window;
     },
     deleteProperty(_: Window, k: PropertyKey) {

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,0 +1,13 @@
+import { FakeDocument, FakeLocation, ISandbox } from "@satumjs/types";
+
+interface ProxySandboxOptions {
+  useSandBox: boolean;
+  winVariable(prop: PropertyKey, vmContext: ISandbox['vmContext'], global: Window): any;
+  docVariable(prop: PropertyKey, proxyDoc: any, document: Document, fakeWin:ISandbox['vmContext']): any;
+  locationVariable(prop: PropertyKey, locationProx: any, location:Location, fakeWin:ISandbox['vmContext']):any;
+}
+
+
+export {
+  ProxySandboxOptions
+}


### PR DESCRIPTION
1. 增加locationVariable 函数劫持
2. 增加了shadow-dom css隔离， 在shadowDom中修复React事件代理，@font-face Rule失效问题
3. 增加沙箱隔离策略， 全局非标准属性隔离到沙箱中，html模板中CDN隔离及全局变量声明隔离
4. 增强沙箱对标全局函数代理过程。